### PR TITLE
暴露完成方法

### DIFF
--- a/TZImagePreviewController/TZImagePreviewController/TZImagePreviewController.h
+++ b/TZImagePreviewController/TZImagePreviewController/TZImagePreviewController.h
@@ -32,4 +32,5 @@
 /// 用户点击了完成按钮
 @property (nonatomic, copy) void (^doneButtonClickBlock)(NSArray *photos,BOOL isSelectOriginalPhoto);
 
+- (void)doneButtonClick;
 @end


### PR DESCRIPTION
有一种业务需求是可选择n张图片,支持本地相册导入以及外部urlist导入,用urllist导入时doneButtonClick方法不一定能直接完成选择功能,应该在方法体内先判断本次选择数加上本地图片选择数是否超过n,所以这个方法暴露在外部可以方便继承该类,重写doneButtonClick方法并在内部判断